### PR TITLE
Update opam

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -23,5 +23,6 @@ depends: [
 depexts: [
   [["debian"] ["libfuse-dev"]]
   [["ubuntu"] ["libfuse-dev"]]
+  [["osx" "homebrew"] ["Caskroom/cask/osxfuse"]]
 ]
 available: [ ocaml-version >= "3.08.0" ]

--- a/opam/opam
+++ b/opam/opam
@@ -24,4 +24,4 @@ depexts: [
   [["debian"] ["libfuse-dev"]]
   [["ubuntu"] ["libfuse-dev"]]
 ]
-available: [ ocaml-version >= "3.08.0" & os != "darwin" ]
+available: [ ocaml-version >= "3.08.0" ]


### PR DESCRIPTION
Since the changes from @jendas1 were [merged](https://github.com/astrada/ocamlfuse/pull/3) we should probably allow opam to install ocamlfuse on mac.

As published, `opam install ocamlfuse` fails with platform check.
With this change `opam pin` installs the package fine.