### PR TITLE
include unistd.h to declare used API functions

### DIFF
--- a/lib/Unix_util_stubs.c
+++ b/lib/Unix_util_stubs.c
@@ -24,6 +24,7 @@
   vincenzo_ml@yahoo.it
 */
 
+#include <unistd.h>
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
With strict CFLAGS ocamlfuse will fail to compile:

$ (cd _build/default/lib && /usr/bin/ocamlc.opt -g -I /usr/lib64/ocaml/camlidl -I /usr/lib64/ocaml/threads -ccopt -I/usr/include/fuse -ccopt -D_FILE_OFFSET_BITS=64 -ccopt -g -o Unix_util_stubs.o Unix_util_stubs.c)
Unix_util_stubs.c: In function 'unix_util_read':
Unix_util_stubs.c:60:9: error: implicit declaration of function 'read'; did you mean 'fread'? [-Werror=implicit-function-declaration]
   60 |   res = read(c_fd, c_data, c_dim);
      |         ^~~~
      |         fread
Unix_util_stubs.c: In function 'unix_util_write':
Unix_util_stubs.c:85:9: error: implicit declaration of function 'write'; did you mean 'fwrite'? [-Werror=implicit-function-declaration]
   85 |   res = write(c_fd, c_data, c_dim);
      |         ^~~~~
      |         fwrite
Unix_util_stubs.c: In function 'unix_util_fchdir':
Unix_util_stubs.c:115:3: error: implicit declaration of function 'fchdir' [-Werror=implicit-function-declaration]
  115 |   fchdir(Int_val(fd));
      |   ^~~~~~
cc1: some warnings being treated as errors

Signed-off-by: Olaf Hering <olaf@aepfle.de>