### PR TITLE
osxfuse -> macfuse

### DIFF
--- a/ocamlfuse.opam
+++ b/ocamlfuse.opam
@@ -23,7 +23,7 @@ depexts: [
   ["fuse-devel"] {os-distribution = "centos"}
   ["fuse-devel"] {os-distribution = "fedora"}
   ["fuse-devel"] {os-family = "suse"}
-  ["Caskroom/cask/osxfuse"] {os = "macos" & os-distribution = "homebrew"}
+  ["macfuse"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "OCaml bindings for FUSE (Filesystem in UserSpacE)"
 description: """


### PR DESCRIPTION
[As of v4, FUSE for OSX has re-branded as macFUSE](https://github.com/osxfuse/osxfuse/releases/tag/macfuse-4.0.0), and begun supporting both Intel and ARM 64 for M1 machines.  [The `osxfuse` homebrew package (which seems to have stopped at v3.11.2) is not supported by M1 machines](https://formulae.brew.sh/cask/osxfuse), while later versions offered under the `macfuse` formula should be compatible with both Intel and ARM64 machines:

- https://github.com/osxfuse/osxfuse/releases

I've tested this with `google-drive-ocamlfuse` using homebrew on MacOS Monterey and things seem to work:

```
brew install macfuse opam
opam init
opam update
opam switch create 4.13.1
# use modified ocamlfuse
opam pin ocamlfuse https://github.com/myedibleenso/ocamlfuse.git#issue20
opam install google-drive-ocamlfuse
```