### PR TITLE
Fix crash after fork if compiled with OCaml 5+

### DIFF
--- a/lib/Fuse_main.c
+++ b/lib/Fuse_main.c
@@ -1,0 +1,99 @@
+/*
+  This file is part of the "OCamlFuse" library.
+
+  OCamlFuse is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation (version 2 of the License).
+
+  OCamlFuse is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OCamlFuse.  See the file LICENSE.  If you haven't received
+  a copy of the GNU General Public License, write to:
+
+  Free Software Foundation, Inc.,
+  59 Temple Place, Suite 330, Boston, MA
+  02111-1307  USA
+
+  Alessandro Strada
+*/
+
+#include <caml/version.h>
+
+#if OCAML_VERSION < 50000
+#define CAML_NAME_SPACE
+#endif
+
+#include <caml/callback.h>
+#include <caml/mlvalues.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define FUSE_USE_VERSION 26
+#include <fuse_lowlevel.h>
+
+char **insert_foreground_option(int argc, char **argv);
+void free_fuse_argv(int n, char **fuse_argv);
+
+/* https://v2.ocaml.org/releases/5.1/htmlman/intfc.html#ss:main-c */
+int main(int argc, char **argv) {
+  int c;
+  int foreground = 0;
+  int res;
+  char **fuse_argv = argv;
+
+  opterr = 0;
+  while ((c = getopt(argc, argv, "f")) != -1) {
+    switch (c) {
+    case 'f':
+      foreground = 1;
+      break;
+    default:
+      break;
+    }
+  }
+
+  /* https://github.com/libfuse/libfuse/blob/d04687923194d906fe5ad82dcd546c9807bf15b6/include/fuse_common.h#L246
+   */
+  if (fuse_daemonize(foreground) == -1) {
+    perror("fuse_daemonize");
+    return 1;
+  }
+
+  if (foreground == 0) {
+    fuse_argv = insert_foreground_option(argc, argv);
+  }
+
+  caml_main(fuse_argv);
+
+  if (foreground == 0) {
+    free_fuse_argv(argc + 1, fuse_argv);
+  }
+
+  return 0;
+}
+
+char **insert_foreground_option(int argc, char **argv) {
+  char *mountpoint = argv[argc - 1];
+  char **new_argv = malloc((argc + 2) * sizeof(*new_argv));
+
+  for (int i = 0; i < argc - 1; ++i) {
+    new_argv[i] = strdup(argv[i]);
+  }
+  new_argv[argc - 1] = strdup("-f");
+  new_argv[argc] = strdup(mountpoint);
+  return new_argv;
+}
+
+void free_fuse_argv(int n, char **fuse_argv) {
+  for (int i = 0; i < n; ++i) {
+    free(fuse_argv[i]);
+  }
+  free(fuse_argv);
+}

--- a/lib/Fuse_util.c
+++ b/lib/Fuse_util.c
@@ -44,6 +44,11 @@
 #include <caml/callback.h>
 #include <caml/threads.h>
 
+#if OCAML_VERSION >= 50000
+CAMLextern void caml_reset_domain_lock(void);
+CAMLextern void caml_acquire_domain_lock(void);
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -679,6 +684,11 @@ void ml_fuse_main(int argc,str * argv,struct fuse_operations const * op)
   int fd;
 
   struct fuse * fuse = fuse_setup(argc,argv,op,sizeof(struct fuse_operations),&mountpoint,&multithreaded,&fd);
+
+#if OCAML_VERSION >= 50000
+  caml_reset_domain_lock();
+  caml_acquire_domain_lock();
+#endif
 
   if (fuse!=NULL)
     {

--- a/lib/Fuse_util.c
+++ b/lib/Fuse_util.c
@@ -32,28 +32,25 @@
 
 #define UNKNOWN_ERR 127
 
-
-#include <caml/mlvalues.h>
-#include <caml/memory.h>
 #include <caml/alloc.h>
-#include <caml/fail.h>
-#include <caml/callback.h>
-#include <caml/custom.h>
 #include <caml/bigarray.h>
-#include <caml/camlidlruntime.h>
-#include <caml/mlvalues.h>
 #include <caml/callback.h>
+#include <caml/camlidlruntime.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
 #include <caml/threads.h>
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <math.h>
-#include <sys/types.h>
 #include <dirent.h>
-#include <sys/stat.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #define FUSE_USE_VERSION 26
 #include <fuse.h>
@@ -62,7 +59,7 @@
 
 #include "Fuse_bindings.h"
 
-#define min(a,b) (a<b?a:b)
+#define min(a, b) (a < b ? a : b)
 
 #if OCAML_VERSION >= 50000
 /* HACK: Internal hook to call after fork()
@@ -70,146 +67,140 @@
 CAMLextern void (*caml_atfork_hook)(void);
 #endif
 
-CAMLprim value callback4(value closure,value arg1,value arg2,value arg3,value arg4)
-{
+CAMLprim value callback4(value closure, value arg1, value arg2, value arg3,
+                         value arg4) {
   CAMLparam5(closure, arg1, arg2, arg3, arg4);
-  CAMLlocalN(args,4);
-  args[0]=arg1;
-  args[1]=arg2;
-  args[2]=arg3;
-  args[3]=arg4;
-  CAMLreturn(caml_callbackN(closure,4,args));
+  CAMLlocalN(args, 4);
+  args[0] = arg1;
+  args[1] = arg2;
+  args[2] = arg3;
+  args[3] = arg4;
+  CAMLreturn(caml_callbackN(closure, 4, args));
 }
 
-CAMLprim value c2ml_setxattr_flags(int flags)
-{
-  CAMLparam0 ();
+CAMLprim value c2ml_setxattr_flags(int flags) {
+  CAMLparam0();
   CAMLlocal1(res);
 
-  if (flags==XATTR_CREATE)
-    {
-      res=Val_int(1);
-    }
-  else if (flags==XATTR_REPLACE)
-    {
-      res=Val_int(2);
-    }
-  else res=Val_int(0);
+  if (flags == XATTR_CREATE) {
+    res = Val_int(1);
+  } else if (flags == XATTR_REPLACE) {
+    res = Val_int(2);
+  } else
+    res = Val_int(0);
 
   CAMLreturn(res);
 }
 
 /* This part shamelessly copied from mlfuse */
-#define ADDFLAGT(T, X)                            \
-  num_ml_constr--;                                \
-  if (T) {                                        \
-    tmp = caml_alloc(2, 0);                       \
-    Store_field (tmp, 0, Val_int(num_ml_constr)); \
-    Store_field (tmp, 1, res);                    \
-    res = tmp;                                    \
+#define ADDFLAGT(T, X)                                                         \
+  num_ml_constr--;                                                             \
+  if (T) {                                                                     \
+    tmp = caml_alloc(2, 0);                                                    \
+    Store_field(tmp, 0, Val_int(num_ml_constr));                               \
+    Store_field(tmp, 1, res);                                                  \
+    res = tmp;                                                                 \
   }
 
-#define ADDFLAG(X) ADDFLAGT(flags & X, X)
+#define ADDFLAG(X) ADDFLAGT(flags &X, X)
 #define ADDBASEFLAG(X) ADDFLAGT((flags & 3) == X, X)
 
-CAMLprim value c_flags_to_open_flag_list (int flags) {
-  CAMLparam0 ();
-  CAMLlocal2 (res, tmp);
+CAMLprim value c_flags_to_open_flag_list(int flags) {
+  CAMLparam0();
+  CAMLlocal2(res, tmp);
   int num_ml_constr = 8;
 
-  res = Val_int (0);
+  res = Val_int(0);
 
-  ADDFLAG (O_EXCL);
-  ADDFLAG (O_TRUNC);
-  ADDFLAG (O_CREAT);
-  ADDFLAG (O_APPEND);
-  ADDFLAG (O_NONBLOCK);
+  ADDFLAG(O_EXCL);
+  ADDFLAG(O_TRUNC);
+  ADDFLAG(O_CREAT);
+  ADDFLAG(O_APPEND);
+  ADDFLAG(O_NONBLOCK);
 
-  ADDBASEFLAG (O_RDWR);
-  ADDBASEFLAG (O_WRONLY);
-  ADDBASEFLAG (O_RDONLY);
+  ADDBASEFLAG(O_RDWR);
+  ADDBASEFLAG(O_WRONLY);
+  ADDBASEFLAG(O_RDONLY);
 
-  CAMLreturn (res);
+  CAMLreturn(res);
 }
 /* End of shame */
 
-static int ml2c_unix_error_vect[] =
-{
-  E2BIG,
-  EACCES,
-  EAGAIN,
-  EBADF,
-  EBUSY,
-  ECHILD,
-  EDEADLK,
-  EDOM ,
-  EEXIST,
-  EFAULT,
-  EFBIG,
-  EINTR,
-  EINVAL,
-  EIO,
-  EISDIR,
-  EMFILE,
-  EMLINK,
-  ENAMETOOLONG,
-  ENFILE,
-  ENODEV,
-  ENOENT,
-  ENOEXEC,
-  ENOLCK,
-  ENOMEM,
-  ENOSPC,
-  ENOSYS,
-  ENOTDIR,
-  ENOTEMPTY,
-  ENOTTY,
-  ENXIO,
-  EPERM,
-  EPIPE,
-  ERANGE,
-  EROFS,
-  ESPIPE,
-  ESRCH,
-  EXDEV,
-  EWOULDBLOCK,
-  EINPROGRESS,
-  EALREADY,
-  ENOTSOCK,
-  EDESTADDRREQ,
-  EMSGSIZE,
-  EPROTOTYPE,
-  ENOPROTOOPT,
-  EPROTONOSUPPORT ,
-  ESOCKTNOSUPPORT ,
-  EOPNOTSUPP,
-  EPFNOSUPPORT,
-  EAFNOSUPPORT,
-  EADDRINUSE,
-  EADDRNOTAVAIL,
-  ENETDOWN,
-  ENETUNREACH,
-  ENETRESET,
-  ECONNABORTED,
-  ECONNRESET,
-  ENOBUFS,
-  EISCONN,
-  ENOTCONN,
-  ESHUTDOWN,
-  ETOOMANYREFS,
-  ETIMEDOUT,
-  ECONNREFUSED,
-  EHOSTDOWN,
-  EHOSTUNREACH,
-  ELOOP,
-  EOVERFLOW,
-  0 /* Terminator for the inverse function */
+static int ml2c_unix_error_vect[] = {
+    E2BIG,
+    EACCES,
+    EAGAIN,
+    EBADF,
+    EBUSY,
+    ECHILD,
+    EDEADLK,
+    EDOM,
+    EEXIST,
+    EFAULT,
+    EFBIG,
+    EINTR,
+    EINVAL,
+    EIO,
+    EISDIR,
+    EMFILE,
+    EMLINK,
+    ENAMETOOLONG,
+    ENFILE,
+    ENODEV,
+    ENOENT,
+    ENOEXEC,
+    ENOLCK,
+    ENOMEM,
+    ENOSPC,
+    ENOSYS,
+    ENOTDIR,
+    ENOTEMPTY,
+    ENOTTY,
+    ENXIO,
+    EPERM,
+    EPIPE,
+    ERANGE,
+    EROFS,
+    ESPIPE,
+    ESRCH,
+    EXDEV,
+    EWOULDBLOCK,
+    EINPROGRESS,
+    EALREADY,
+    ENOTSOCK,
+    EDESTADDRREQ,
+    EMSGSIZE,
+    EPROTOTYPE,
+    ENOPROTOOPT,
+    EPROTONOSUPPORT,
+    ESOCKTNOSUPPORT,
+    EOPNOTSUPP,
+    EPFNOSUPPORT,
+    EAFNOSUPPORT,
+    EADDRINUSE,
+    EADDRNOTAVAIL,
+    ENETDOWN,
+    ENETUNREACH,
+    ENETRESET,
+    ECONNABORTED,
+    ECONNRESET,
+    ENOBUFS,
+    EISCONN,
+    ENOTCONN,
+    ESHUTDOWN,
+    ETOOMANYREFS,
+    ETIMEDOUT,
+    ECONNREFUSED,
+    EHOSTDOWN,
+    EHOSTUNREACH,
+    ELOOP,
+    EOVERFLOW,
+    0 /* Terminator for the inverse function */
 };
 
-static int ml2c_unix_error_vect_dim=0;
+static int ml2c_unix_error_vect_dim = 0;
 
-int ml2c_unix_error(int ocaml_err)
-{
+int ml2c_unix_error(int ocaml_err) {
   if (ocaml_err < ml2c_unix_error_vect_dim)
     return ml2c_unix_error_vect[ocaml_err];
   return UNKNOWN_ERR; /* TODO: find an appropriate value */
@@ -217,124 +208,117 @@ int ml2c_unix_error(int ocaml_err)
 
 /* TODO: This sucks */
 
-int * invert_array(int * src,int * indim,int * outdim)
-{
+int *invert_array(int *src, int *indim, int *outdim) {
   /* Find dimensions */
-  int dim=0;
-  int i=0;
+  int dim = 0;
+  int i = 0;
   int srcdim = 0;
 
-  while (src[srcdim]!=0)
-    {
-      if (src[srcdim]+1>dim) dim=src[srcdim]+1;
-      srcdim++;
-    }
+  while (src[srcdim] != 0) {
+    if (src[srcdim] + 1 > dim)
+      dim = src[srcdim] + 1;
+    srcdim++;
+  }
 
   /* Create the result */
-  int * res = malloc(dim * sizeof(int));
-  for (i = 0;i < dim;i++) res[i]=UNKNOWN_ERR; /* TODO: find a meaningful value */
+  int *res = malloc(dim * sizeof(int));
+  for (i = 0; i < dim; i++)
+    res[i] = UNKNOWN_ERR; /* TODO: find a meaningful value */
 
   /* Invert the array */
-  for (i = 0;i < srcdim;i++) res[src[i]]=i;
+  for (i = 0; i < srcdim; i++)
+    res[src[i]] = i;
 
-  *indim=srcdim;
-  *outdim=dim;
+  *indim = srcdim;
+  *outdim = dim;
   return res;
 }
 
-static int c2ml_unix_error_vect_dim=0;
-static int * c2ml_unix_error_vect;
+static int c2ml_unix_error_vect_dim = 0;
+static int *c2ml_unix_error_vect;
 
-int c2ml_unix_error(int c_err)
-{
+int c2ml_unix_error(int c_err) {
   if (c_err < c2ml_unix_error_vect_dim)
     return c2ml_unix_error_vect[c_err];
-  return UNKNOWN_ERR; /* TODO: find a meaningful value (also search for UNKNOWN_ERR in this file */
+  return UNKNOWN_ERR; /* TODO: find a meaningful value (also search for
+                         UNKNOWN_ERR in this file */
 }
 
 /* end "Thisk sucks" part */
 
-int ml2c_unix_file_kind[] =
-{
-  S_IFREG,
-  S_IFDIR,
-  S_IFCHR,
-  S_IFBLK,
-  S_IFLNK,
-  S_IFIFO,
-  S_IFSOCK
-};
+int ml2c_unix_file_kind[] = {S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK,
+                             S_IFLNK, S_IFIFO, S_IFSOCK};
 
-void ml2c_Unix_stats_struct_stat(value v,struct stat * s)
-{
+void ml2c_Unix_stats_struct_stat(value v, struct stat *s) {
   CAMLparam1(v);
-  memset(s,0,sizeof(*s));
-  s->st_dev=Int_val(Field(v,0));
-  s->st_ino=Int_val(Field(v,1));
-  s->st_mode=0 | Int_val(Field(v,3)) | ml2c_unix_file_kind[Int_val(Field(v,2))];
-  s->st_nlink=Int_val(Field(v,4));
-  s->st_uid=Int_val(Field(v,5));
-  s->st_gid=Int_val(Field(v,6));
-  s->st_rdev=Int_val(Field(v,7));
-  s->st_size=Int64_val(Field(v,8));
-  s->st_blksize=512; /* TODO: STUB, at least use the one from statfs */
-  s->st_blocks=ceil(((double)s->st_size)/((double)s->st_blksize)); /* TODO: STUB! */
-  s->st_atime=Double_val(Field(v,9));
-  s->st_mtime=Double_val(Field(v,10));
-  s->st_ctime=Double_val(Field(v,11));
+  memset(s, 0, sizeof(*s));
+  s->st_dev = Int_val(Field(v, 0));
+  s->st_ino = Int_val(Field(v, 1));
+  s->st_mode =
+      0 | Int_val(Field(v, 3)) | ml2c_unix_file_kind[Int_val(Field(v, 2))];
+  s->st_nlink = Int_val(Field(v, 4));
+  s->st_uid = Int_val(Field(v, 5));
+  s->st_gid = Int_val(Field(v, 6));
+  s->st_rdev = Int_val(Field(v, 7));
+  s->st_size = Int64_val(Field(v, 8));
+  s->st_blksize = 512; /* TODO: STUB, at least use the one from statfs */
+  s->st_blocks =
+      ceil(((double)s->st_size) / ((double)s->st_blksize)); /* TODO: STUB! */
+  s->st_atime = Double_val(Field(v, 9));
+  s->st_mtime = Double_val(Field(v, 10));
+  s->st_ctime = Double_val(Field(v, 11));
   CAMLreturn0;
 }
 
-void ml2c_Unix_struct_statvfs(value v,struct statvfs * st)
-{
+void ml2c_Unix_struct_statvfs(value v, struct statvfs *st) {
   CAMLparam1(v);
-  memset(st,0,sizeof(*st));
-  st->f_bsize = Int64_val(Field(v,0));
-  st->f_frsize = Int64_val(Field(v,1));
-  st->f_blocks = Int64_val(Field(v,2));
-  st->f_bfree = Int64_val(Field(v,3));
-  st->f_bavail = Int64_val(Field(v,4));
-  st->f_files = Int64_val(Field(v,5));
-  st->f_ffree = Int64_val(Field(v,6));
-  st->f_favail = Int64_val(Field(v,7));
-  st->f_fsid = Int64_val(Field(v,8));
-  st->f_flag = Int64_val(Field(v,9));
-  st->f_namemax = Int64_val(Field(v,10));
+  memset(st, 0, sizeof(*st));
+  st->f_bsize = Int64_val(Field(v, 0));
+  st->f_frsize = Int64_val(Field(v, 1));
+  st->f_blocks = Int64_val(Field(v, 2));
+  st->f_bfree = Int64_val(Field(v, 3));
+  st->f_bavail = Int64_val(Field(v, 4));
+  st->f_files = Int64_val(Field(v, 5));
+  st->f_ffree = Int64_val(Field(v, 6));
+  st->f_favail = Int64_val(Field(v, 7));
+  st->f_fsid = Int64_val(Field(v, 8));
+  st->f_flag = Int64_val(Field(v, 9));
+  st->f_namemax = Int64_val(Field(v, 10));
   CAMLreturn0;
   /* TODO: check the meaning of the following missing field:
      __f_spare
    */
 }
 
-#define FOR_ALL_OPS(MACRO)                      \
-  MACRO(init)                                   \
-  MACRO(getattr)                                \
-  MACRO(readlink)                               \
-  MACRO(readdir)                                \
-  MACRO(opendir)                                \
-  MACRO(releasedir)                             \
-  MACRO(fsyncdir)                               \
-  MACRO(mknod)                                  \
-  MACRO(mkdir)                                  \
-  MACRO(symlink)                                \
-  MACRO(unlink)                                 \
-  MACRO(rmdir)                                  \
-  MACRO(rename)                                 \
-  MACRO(link)                                   \
-  MACRO(chmod)                                  \
-  MACRO(chown)                                  \
-  MACRO(truncate)                               \
-  MACRO(utime)                                  \
-  MACRO(open)                                   \
-  MACRO(read)                                   \
-  MACRO(write)                                  \
-  MACRO(statfs)                                 \
-  MACRO(release)                                \
-  MACRO(flush)                                  \
-  MACRO(fsync)                                  \
-  MACRO(setxattr)                               \
-  MACRO(getxattr)                               \
-  MACRO(listxattr)                              \
+#define FOR_ALL_OPS(MACRO)                                                     \
+  MACRO(init)                                                                  \
+  MACRO(getattr)                                                               \
+  MACRO(readlink)                                                              \
+  MACRO(readdir)                                                               \
+  MACRO(opendir)                                                               \
+  MACRO(releasedir)                                                            \
+  MACRO(fsyncdir)                                                              \
+  MACRO(mknod)                                                                 \
+  MACRO(mkdir)                                                                 \
+  MACRO(symlink)                                                               \
+  MACRO(unlink)                                                                \
+  MACRO(rmdir)                                                                 \
+  MACRO(rename)                                                                \
+  MACRO(link)                                                                  \
+  MACRO(chmod)                                                                 \
+  MACRO(chown)                                                                 \
+  MACRO(truncate)                                                              \
+  MACRO(utime)                                                                 \
+  MACRO(open)                                                                  \
+  MACRO(read)                                                                  \
+  MACRO(write)                                                                 \
+  MACRO(statfs)                                                                \
+  MACRO(release)                                                               \
+  MACRO(flush)                                                                 \
+  MACRO(fsync)                                                                 \
+  MACRO(setxattr)                                                              \
+  MACRO(getxattr)                                                              \
+  MACRO(listxattr)                                                             \
   MACRO(removexattr)
 
 /*
@@ -348,358 +332,418 @@ void ml2c_Unix_struct_statvfs(value v,struct statvfs * st)
    int(* 	create )(const char *, mode_t, struct fuse_file_info *)
    int(* 	ftruncate )(const char *, off_t, struct fuse_file_info *)
    int(* 	fgetattr )(const char *, struct stat *, struct fuse_file_info *)
-   int(* 	lock )(const char *, struct fuse_file_info *, int cmd, struct flock *)
-   int(* 	utimens )(const char *, const struct timespec tv[2])
+   int(* 	lock )(const char *, struct fuse_file_info *, int cmd, struct
+   flock *) int(* 	utimens )(const char *, const struct timespec tv[2])
    int(* 	bmap )(const char *, size_t blocksize, uint64_t *idx)
-   int(* 	ioctl )(const char *, int cmd, void *arg, struct fuse_file_info *, unsigned int flags, void *data)
-   int(* 	poll )(const char *, struct fuse_file_info *, struct fuse_pollhandle *ph, unsigned *reventsp)
+   int(* 	ioctl )(const char *, int cmd, void *arg, struct fuse_file_info *,
+   unsigned int flags, void *data) int(* 	poll )(const char *, struct
+   fuse_file_info *, struct fuse_pollhandle *ph, unsigned *reventsp)
 */
 
 #define SET_NULL_OP(OPNAME) .OPNAME = NULL,
 
-static struct fuse_operations ops = {
-  FOR_ALL_OPS(SET_NULL_OP)
-};
+static struct fuse_operations ops = {FOR_ALL_OPS(SET_NULL_OP)};
 
-static const value * ocaml_list_length=NULL;
+static const value *ocaml_list_length = NULL;
 
-#define DECLARE_OP_CLOSURE(OPNAME) static const value * OPNAME##_closure=NULL;
+#define DECLARE_OP_CLOSURE(OPNAME) static const value *OPNAME##_closure = NULL;
 FOR_ALL_OPS(DECLARE_OP_CLOSURE)
 
-#define init_ARGS (struct fuse_conn_info *conn)
+#define init_ARGS (struct fuse_conn_info * conn)
 #define init_CALL_ARGS (conn)
 #define init_RTYPE void *
-#define init_CB vres=caml_callback(*init_closure,Val_unit);
+#define init_CB vres = caml_callback(*init_closure, Val_unit);
 /* TODO: the result from init is wrong, it should return unit */
 #define init_RES
 
-#define getattr_ARGS (const char* path, struct stat * buf)
+#define getattr_ARGS (const char *path, struct stat *buf)
 #define getattr_CALL_ARGS (path, buf)
 #define getattr_RTYPE int
-#define getattr_CB vpath = caml_copy_string(path); vres=caml_callback(*getattr_closure,vpath);
-#define getattr_RES \
-  ml2c_Unix_stats_struct_stat(Field(vres,0),buf);
+#define getattr_CB                                                             \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback(*getattr_closure, vpath);
+#define getattr_RES ml2c_Unix_stats_struct_stat(Field(vres, 0), buf);
 
 /* TODO: allow ocaml to use the offset and the stat argument of the filler */
-#define readdir_ARGS (const char * path, void * buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info * info)
+#define readdir_ARGS                                                           \
+  (const char *path, void *buf, fuse_fill_dir_t filler, off_t offset,          \
+   struct fuse_file_info *info)
 #define readdir_CALL_ARGS (path, buf, filler, offset, info)
 #define readdir_RTYPE int
-#define readdir_CB vpath = caml_copy_string(path); vres=caml_callback2(*readdir_closure,vpath,Val_int(info->fh));
-#define readdir_RES                                           \
-  vtmp=Field(vres,0);                                         \
-  while (Is_block(vtmp))                                      \
-  {                                                           \
-    if (filler(buf,String_val(Field(vtmp,0)),NULL,0)) break;  \
-    if (res != 0) break;                                      \
-    vtmp=Field(vtmp,1);                                       \
+#define readdir_CB                                                             \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*readdir_closure, vpath, Val_int(info->fh));
+#define readdir_RES                                                            \
+  vtmp = Field(vres, 0);                                                       \
+  while (Is_block(vtmp)) {                                                     \
+    if (filler(buf, String_val(Field(vtmp, 0)), NULL, 0))                      \
+      break;                                                                   \
+    if (res != 0)                                                              \
+      break;                                                                   \
+    vtmp = Field(vtmp, 1);                                                     \
   }
 
 #define mknod_ARGS (const char *path, mode_t mode, dev_t rdev)
 #define mknod_CALL_ARGS (path, mode, rdev)
 #define mknod_RTYPE int
-#define mknod_CB vpath = caml_copy_string(path); vres=caml_callback2(*mknod_closure,vpath,Val_int(mode));
+#define mknod_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*mknod_closure, vpath, Val_int(mode));
 #define mknod_RES
 
 #define mkdir_ARGS (const char *path, mode_t mode)
 #define mkdir_CALL_ARGS (path, mode)
 #define mkdir_RTYPE int
-#define mkdir_CB vpath = caml_copy_string(path); vres=caml_callback2(*mkdir_closure,vpath,Val_int(mode));
+#define mkdir_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*mkdir_closure, vpath, Val_int(mode));
 #define mkdir_RES
 
 #define unlink_ARGS (const char *path)
 #define unlink_CALL_ARGS (path)
 #define unlink_RTYPE int
-#define unlink_CB vpath = caml_copy_string(path); vres=caml_callback(*unlink_closure,vpath);
+#define unlink_CB                                                              \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback(*unlink_closure, vpath);
 #define unlink_RES
 
 #define rmdir_ARGS (const char *path)
 #define rmdir_CALL_ARGS (path)
 #define rmdir_RTYPE int
-#define rmdir_CB vpath = caml_copy_string(path); vres=caml_callback(*rmdir_closure,vpath);
+#define rmdir_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback(*rmdir_closure, vpath);
 #define rmdir_RES
 
 #define readlink_ARGS (const char *path, char *buf, size_t size)
 #define readlink_CALL_ARGS (path, buf, size)
 #define readlink_RTYPE int
-#define readlink_CB vpath = caml_copy_string(path); vres=caml_callback(*readlink_closure,vpath);
-#define readlink_RES strncpy(buf,String_val(Field(vres,0)),size-1);
+#define readlink_CB                                                            \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback(*readlink_closure, vpath);
+#define readlink_RES strncpy(buf, String_val(Field(vres, 0)), size - 1);
 
 #define symlink_ARGS (const char *path, const char *dest)
 #define symlink_CALL_ARGS (path, dest)
 #define symlink_RTYPE int
-#define symlink_CB                                  \
-  vpath = caml_copy_string(path);                   \
-  vtmp = caml_copy_string(dest);                    \
-  vres=caml_callback2(*symlink_closure,vpath,vtmp);
+#define symlink_CB                                                             \
+  vpath = caml_copy_string(path);                                              \
+  vtmp = caml_copy_string(dest);                                               \
+  vres = caml_callback2(*symlink_closure, vpath, vtmp);
 #define symlink_RES
 
 #define rename_ARGS (const char *path, const char *dest)
 #define rename_CALL_ARGS (path, dest)
 #define rename_RTYPE int
-#define rename_CB                                   \
-  vpath = caml_copy_string(path);                   \
-  vtmp = caml_copy_string(dest);                    \
-  vres=caml_callback2(*rename_closure,vpath,vtmp);
+#define rename_CB                                                              \
+  vpath = caml_copy_string(path);                                              \
+  vtmp = caml_copy_string(dest);                                               \
+  vres = caml_callback2(*rename_closure, vpath, vtmp);
 #define rename_RES
 
 #define link_ARGS (const char *path, const char *dest)
 #define link_CALL_ARGS (path, dest)
 #define link_RTYPE int
-#define link_CB                                   \
-  vpath = caml_copy_string(path);                 \
-  vtmp = caml_copy_string(dest);                  \
-  vres=caml_callback2(*link_closure,vpath,vtmp);
+#define link_CB                                                                \
+  vpath = caml_copy_string(path);                                              \
+  vtmp = caml_copy_string(dest);                                               \
+  vres = caml_callback2(*link_closure, vpath, vtmp);
 #define link_RES
 
 #define chmod_ARGS (const char *path, mode_t mode)
 #define chmod_CALL_ARGS (path, mode)
 #define chmod_RTYPE int
-#define chmod_CB vpath = caml_copy_string(path); vres=caml_callback2(*chmod_closure,vpath,Val_int(mode));
+#define chmod_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*chmod_closure, vpath, Val_int(mode));
 #define chmod_RES
 
 #define chown_ARGS (const char *path, uid_t uid, gid_t gid)
 #define chown_CALL_ARGS (path, uid, gid)
 #define chown_RTYPE int
-#define chown_CB vpath = caml_copy_string(path); vres=caml_callback3(*chown_closure,vpath,Val_int(uid),Val_int(gid));
+#define chown_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback3(*chown_closure, vpath, Val_int(uid), Val_int(gid));
 #define chown_RES
 
 #define truncate_ARGS (const char *path, off_t size)
 #define truncate_CALL_ARGS (path, size)
 #define truncate_RTYPE int
-#define truncate_CB vpath = caml_copy_string(path); vres=caml_callback2(*truncate_closure,vpath,caml_copy_int64(size));
+#define truncate_CB                                                            \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*truncate_closure, vpath, caml_copy_int64(size));
 #define truncate_RES
 
 #define utime_ARGS (const char *path, struct utimbuf *buf)
 #define utime_CALL_ARGS (path, buf)
 #define utime_RTYPE int
-#define utime_CB vpath = caml_copy_string(path); vres=caml_callback3(*utime_closure,vpath,caml_copy_double(buf->actime),caml_copy_double(buf->modtime));
+#define utime_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback3(*utime_closure, vpath, caml_copy_double(buf->actime),  \
+                        caml_copy_double(buf->modtime));
 #define utime_RES
 
 #define open_ARGS (const char *path, struct fuse_file_info *fi)
 #define open_CALL_ARGS (path, fi)
 #define open_RTYPE int
-#define open_CB vpath = caml_copy_string(path); vres=caml_callback2(*open_closure,vpath,c_flags_to_open_flag_list(fi->flags));
-#define open_RES if (Field(vres,0) != Val_int(0)) fi->fh = Int_val(Field(Field(vres,0),0));
+#define open_CB                                                                \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*open_closure, vpath,                                  \
+                        c_flags_to_open_flag_list(fi->flags));
+#define open_RES                                                               \
+  if (Field(vres, 0) != Val_int(0))                                            \
+    fi->fh = Int_val(Field(Field(vres, 0), 0));
 
 #define opendir_ARGS (const char *path, struct fuse_file_info *fi)
 #define opendir_CALL_ARGS (path, fi)
 #define opendir_RTYPE int
-#define opendir_CB vpath = caml_copy_string(path); vres=caml_callback2(*opendir_closure,vpath,c_flags_to_open_flag_list(fi->flags));
-#define opendir_RES if (Field(vres,0) != Val_int(0)) fi->fh = Int_val(Field(Field(vres,0),0));
+#define opendir_CB                                                             \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*opendir_closure, vpath,                               \
+                        c_flags_to_open_flag_list(fi->flags));
+#define opendir_RES                                                            \
+  if (Field(vres, 0) != Val_int(0))                                            \
+    fi->fh = Int_val(Field(Field(vres, 0), 0));
 
-#define read_ARGS (const char *path, char *buf, size_t size, off_t offset,struct fuse_file_info * fi)
-#define read_CALL_ARGS (path, buf, size, offset,fi)
+#define read_ARGS                                                              \
+  (const char *path, char *buf, size_t size, off_t offset,                     \
+   struct fuse_file_info *fi)
+#define read_CALL_ARGS (path, buf, size, offset, fi)
 #define read_RTYPE int
-#define read_CB                                                         \
-  vpath = caml_copy_string(path);                                       \
-  vres=callback4(*read_closure,vpath,caml_ba_alloc_dims(CAML_BA_UINT8|CAML_BA_C_LAYOUT,1,buf,size),caml_copy_int64(offset),Val_int(fi->fh));
-#define read_RES res=Int_val(Field(vres,0));
+#define read_CB                                                                \
+  vpath = caml_copy_string(path);                                              \
+  vres = callback4(                                                            \
+      *read_closure, vpath,                                                    \
+      caml_ba_alloc_dims(CAML_BA_UINT8 | CAML_BA_C_LAYOUT, 1, buf, size),      \
+      caml_copy_int64(offset), Val_int(fi->fh));
+#define read_RES res = Int_val(Field(vres, 0));
 
-#define write_ARGS (const char *path, const char *buf, size_t size,off_t offset,struct fuse_file_info * fi) /* TODO: check usage of the writepages field of fi */
-#define write_CALL_ARGS (path, buf, size,offset,fi)
+#define write_ARGS                                                             \
+  (const char *path, const char *buf, size_t size, off_t offset,               \
+   struct fuse_file_info                                                       \
+       *fi) /* TODO: check usage of the writepages field of fi */
+#define write_CALL_ARGS (path, buf, size, offset, fi)
 #define write_RTYPE int
-#define write_CB                                                        \
-  vpath = caml_copy_string(path);                                       \
-  vres=callback4(*write_closure,vpath,caml_ba_alloc_dims(CAML_BA_UINT8|CAML_BA_C_LAYOUT,1,(char *)buf,size),caml_copy_int64(offset),Val_int(fi->fh));
-#define write_RES res=Int_val(Field(vres,0));
+#define write_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = callback4(*write_closure, vpath,                                      \
+                   caml_ba_alloc_dims(CAML_BA_UINT8 | CAML_BA_C_LAYOUT, 1,     \
+                                      (char *)buf, size),                      \
+                   caml_copy_int64(offset), Val_int(fi->fh));
+#define write_RES res = Int_val(Field(vres, 0));
 
-#define release_ARGS (const char *path, struct fuse_file_info * fi)
+#define release_ARGS (const char *path, struct fuse_file_info *fi)
 #define release_CALL_ARGS (path, fi)
 #define release_RTYPE int
-#define release_CB vpath = caml_copy_string(path); vres=caml_callback3(*release_closure,vpath,c_flags_to_open_flag_list(fi->flags),Val_int(fi->fh));
+#define release_CB                                                             \
+  vpath = caml_copy_string(path);                                              \
+  vres =                                                                       \
+      caml_callback3(*release_closure, vpath,                                  \
+                     c_flags_to_open_flag_list(fi->flags), Val_int(fi->fh));
 #define release_RES
 
-#define releasedir_ARGS (const char *path, struct fuse_file_info * fi)
+#define releasedir_ARGS (const char *path, struct fuse_file_info *fi)
 #define releasedir_CALL_ARGS (path, fi)
 #define releasedir_RTYPE int
-#define releasedir_CB vpath = caml_copy_string(path); vres=caml_callback3(*releasedir_closure,vpath,c_flags_to_open_flag_list(fi->flags),Val_int(fi->fh));
+#define releasedir_CB                                                          \
+  vpath = caml_copy_string(path);                                              \
+  vres =                                                                       \
+      caml_callback3(*releasedir_closure, vpath,                               \
+                     c_flags_to_open_flag_list(fi->flags), Val_int(fi->fh));
 #define releasedir_RES
 
-#define flush_ARGS (const char *path,struct fuse_file_info * fi)
+#define flush_ARGS (const char *path, struct fuse_file_info *fi)
 #define flush_CALL_ARGS (path, fi)
 #define flush_RTYPE int
-#define flush_CB vpath = caml_copy_string(path); vres=caml_callback2(*flush_closure,vpath,Val_int(fi->fh));
+#define flush_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*flush_closure, vpath, Val_int(fi->fh));
 #define flush_RES
 
 #define statfs_ARGS (const char *path, struct statvfs *stbuf)
 #define statfs_CALL_ARGS (path, stbuf)
 #define statfs_RTYPE int
-#define statfs_CB vpath = caml_copy_string(path); vres=caml_callback(*statfs_closure,vpath);
-#define statfs_RES ml2c_Unix_struct_statvfs(Field(vres,0),stbuf);
+#define statfs_CB                                                              \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback(*statfs_closure, vpath);
+#define statfs_RES ml2c_Unix_struct_statvfs(Field(vres, 0), stbuf);
 
-#define fsync_ARGS (const char *path, int isdatasync,struct fuse_file_info * fi)
+#define fsync_ARGS (const char *path, int isdatasync, struct fuse_file_info *fi)
 #define fsync_CALL_ARGS (path, isdatasync, fi)
 #define fsync_RTYPE int
-#define fsync_CB vpath = caml_copy_string(path); vres=caml_callback3(*fsync_closure,vpath,Val_bool(isdatasync),Val_int(fi->fh));
+#define fsync_CB                                                               \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback3(*fsync_closure, vpath, Val_bool(isdatasync),           \
+                        Val_int(fi->fh));
 #define fsync_RES
 
-#define fsyncdir_ARGS (const char *path, int isdatasync,struct fuse_file_info * fi)
+#define fsyncdir_ARGS                                                          \
+  (const char *path, int isdatasync, struct fuse_file_info *fi)
 #define fsyncdir_CALL_ARGS (path, isdatasync, fi)
 #define fsyncdir_RTYPE int
-#define fsyncdir_CB vpath = caml_copy_string(path); vres=caml_callback3(*fsync_closure,vpath,Val_bool(isdatasync),Val_int(fi->fh));
+#define fsyncdir_CB                                                            \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback3(*fsync_closure, vpath, Val_bool(isdatasync),           \
+                        Val_int(fi->fh));
 #define fsyncdir_RES
 
-#define setxattr_ARGS (const char *path, const char *name, const char *val,size_t size,int flags)
+#define setxattr_ARGS                                                          \
+  (const char *path, const char *name, const char *val, size_t size, int flags)
 #define setxattr_CALL_ARGS (path, name, val, size, flags)
 #define setxattr_RTYPE int
-#define setxattr_CB                                                     \
-  vpath = caml_copy_string(path);                                       \
-  vstring = caml_alloc_string(size);                                    \
-  memcpy(&Byte(String_val(vstring),0),val,size);                        \
-  vres=callback4(*setxattr_closure,vpath,caml_copy_string(name),vstring,c2ml_setxattr_flags(flags));
+#define setxattr_CB                                                            \
+  vpath = caml_copy_string(path);                                              \
+  vstring = caml_alloc_string(size);                                           \
+  memcpy(&Byte(String_val(vstring), 0), val, size);                            \
+  vres = callback4(*setxattr_closure, vpath, caml_copy_string(name), vstring,  \
+                   c2ml_setxattr_flags(flags));
 #define setxattr_RES
 
-#define getxattr_ARGS (const char *path, const char *name, char *val,size_t size)
+#define getxattr_ARGS                                                          \
+  (const char *path, const char *name, char *val, size_t size)
 #define getxattr_CALL_ARGS (path, name, val, size)
 #define getxattr_RTYPE int
-#define getxattr_CB                                                     \
-  vpath = caml_copy_string(path);                                       \
-  vres=caml_callback2(*getxattr_closure,vpath,caml_copy_string(name));
-#define getxattr_RES                                                    \
-  res=caml_string_length(Field(vres,0));                                \
-  if (size > 0)                                                         \
-    if (caml_string_length(Field(vres,0))>=size)                        \
-    {                                                                   \
-      res = -UNKNOWN_ERR;                                               \
-    }                                                                   \
-    else                                                                \
-    {                                                                   \
-      memcpy(val,String_val(Field(vres,0)),caml_string_length(Field(vres,0))); \
+#define getxattr_CB                                                            \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*getxattr_closure, vpath, caml_copy_string(name));
+#define getxattr_RES                                                           \
+  res = caml_string_length(Field(vres, 0));                                    \
+  if (size > 0)                                                                \
+    if (caml_string_length(Field(vres, 0)) >= size) {                          \
+      res = -UNKNOWN_ERR;                                                      \
+    } else {                                                                   \
+      memcpy(val, String_val(Field(vres, 0)),                                  \
+             caml_string_length(Field(vres, 0)));                              \
     }
 
 #define listxattr_ARGS (const char *path, char *list, size_t size)
 #define listxattr_CALL_ARGS (path, list, size)
 #define listxattr_RTYPE int
-#define listxattr_CB vpath = caml_copy_string(path); vres=caml_callback(*listxattr_closure,vpath);
-#define listxattr_RES                               \
-  vtmp=Field(Field(vres,0),0);                      \
-  int len;                                          \
-  char * dest=list;                                 \
-  int rem=size;                                     \
-  if (size==0)                                      \
-  {                                                 \
-    res = Int_val(Field(Field(vres,0),1));          \
-  }                                                 \
-  else                                              \
-  {                                                 \
-    while (Is_block(vtmp))                          \
-    {                                               \
-      len = caml_string_length(Field(vtmp,0))+1;    \
-      if (rem>=len)                                 \
-      {                                             \
-        memcpy(dest,String_val(Field(vtmp,0)),len); \
-        vtmp=Field(vtmp,1);                         \
-        dest+=len;                                  \
-        rem=rem-len;                                \
-      }                                             \
-      else                                          \
-      {                                             \
-        res = -ERANGE;                              \
-        break;                                      \
-      }                                             \
-    }                                               \
-    res=size-rem;                                   \
+#define listxattr_CB                                                           \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback(*listxattr_closure, vpath);
+#define listxattr_RES                                                          \
+  vtmp = Field(Field(vres, 0), 0);                                             \
+  int len;                                                                     \
+  char *dest = list;                                                           \
+  int rem = size;                                                              \
+  if (size == 0) {                                                             \
+    res = Int_val(Field(Field(vres, 0), 1));                                   \
+  } else {                                                                     \
+    while (Is_block(vtmp)) {                                                   \
+      len = caml_string_length(Field(vtmp, 0)) + 1;                            \
+      if (rem >= len) {                                                        \
+        memcpy(dest, String_val(Field(vtmp, 0)), len);                         \
+        vtmp = Field(vtmp, 1);                                                 \
+        dest += len;                                                           \
+        rem = rem - len;                                                       \
+      } else {                                                                 \
+        res = -ERANGE;                                                         \
+        break;                                                                 \
+      }                                                                        \
+    }                                                                          \
+    res = size - rem;                                                          \
   }
 
 #define removexattr_ARGS (const char *path, const char *name)
 #define removexattr_CALL_ARGS (path, name)
 #define removexattr_RTYPE int
-#define removexattr_CB vpath = caml_copy_string(path); vres=caml_callback2(*removexattr_closure,vpath,caml_copy_string(name));
+#define removexattr_CB                                                         \
+  vpath = caml_copy_string(path);                                              \
+  vres = caml_callback2(*removexattr_closure, vpath, caml_copy_string(name));
 #define removexattr_RES
 
-#define CALLBACK(OPNAME)                                                \
-  static OPNAME##_RTYPE gm281_ops_##OPNAME OPNAME##_ARGS                \
-  {                                                                     \
-    CAMLparam0();                                                       \
-    CAMLlocal4(vstring, vpath, vres, vtmp);                             \
-    OPNAME##_RTYPE res=(typeof (res))-1L;                               \
-    OPNAME##_CB                                                         \
-      if (Tag_val(vres)==1) /* Result is not Bad */                     \
-      {                                                                 \
-        res=(typeof (res))0L;                                           \
-        OPNAME##_RES /* res can be changed here */                      \
-      }                                                                 \
-      else                                                              \
-      {                                                                 \
-        if (Is_block(Field(vres,0)))  /* This is EUNKNOWNERR of int in ocaml */ \
-          res=(typeof (res))(long)-Int_val(Field(Field(vres,0),0));     \
-        else res=(typeof (res))(long)-ml2c_unix_error(Int_val(Field(vres,0))); \
-      }                                                                 \
-    CAMLreturnT(OPNAME##_RTYPE, res);                                   \
-  }                                                                     \
-                                                                        \
-  static OPNAME##_RTYPE ops_##OPNAME OPNAME##_ARGS                      \
-  {                                                                     \
-    caml_acquire_runtime_system();                                      \
-    OPNAME##_RTYPE ret = gm281_ops_##OPNAME OPNAME##_CALL_ARGS;         \
-    caml_release_runtime_system();                                      \
-    return ret;                                                         \
+#define CALLBACK(OPNAME)                                                       \
+  static OPNAME##_RTYPE gm281_ops_##OPNAME OPNAME##_ARGS {                     \
+    CAMLparam0();                                                              \
+    CAMLlocal4(vstring, vpath, vres, vtmp);                                    \
+    OPNAME##_RTYPE res = (typeof(res))-1L;                                     \
+    OPNAME##_CB if (Tag_val(vres) == 1) /* Result is not Bad */                \
+    {                                                                          \
+      res = (typeof(res))0L;                                                   \
+      OPNAME##_RES /* res can be changed here */                               \
+    }                                                                          \
+    else {                                                                     \
+      if (Is_block(Field(vres, 0))) /* This is EUNKNOWNERR of int in ocaml */  \
+        res = (typeof(res))(long)-Int_val(Field(Field(vres, 0), 0));           \
+      else                                                                     \
+        res = (typeof(res))(long)-ml2c_unix_error(Int_val(Field(vres, 0)));    \
+    }                                                                          \
+    CAMLreturnT(OPNAME##_RTYPE, res);                                          \
+  }                                                                            \
+                                                                               \
+  static OPNAME##_RTYPE ops_##OPNAME OPNAME##_ARGS {                           \
+    caml_acquire_runtime_system();                                             \
+    OPNAME##_RTYPE ret = gm281_ops_##OPNAME OPNAME##_CALL_ARGS;                \
+    caml_release_runtime_system();                                             \
+    return ret;                                                                \
   }
 
 FOR_ALL_OPS(CALLBACK)
 
-#define SET_OPERATION(OPNAME)                       \
-  if (op->OPNAME==NULL) ops.OPNAME=NULL;            \
-  else                                              \
-  {                                                 \
-    OPNAME##_closure=caml_named_value(op->OPNAME);  \
-    ops.OPNAME=ops_##OPNAME;                        \
+#define SET_OPERATION(OPNAME)                                                  \
+  if (op->OPNAME == NULL)                                                      \
+    ops.OPNAME = NULL;                                                         \
+  else {                                                                       \
+    OPNAME##_closure = caml_named_value(op->OPNAME);                           \
+    ops.OPNAME = ops_##OPNAME;                                                 \
   }
 
-void set_fuse_operations(struct fuse_operation_names const *op)
-{
+void set_fuse_operations(struct fuse_operation_names const *op) {
   FOR_ALL_OPS(SET_OPERATION)
 }
 
-struct fuse_operations * get_fuse_operations()
-{
+struct fuse_operations *get_fuse_operations() {
   return &ops;
 }
 
-const value * ocaml_fuse_loop_closure;
+const value *ocaml_fuse_loop_closure;
 
-int mainloop(struct fuse * f,int multithreaded)
-{
+int mainloop(struct fuse *f, int multithreaded) {
   CAMLparam0();
   if (f == NULL)
-    return(-1);
+    return (-1);
 
   CAMLlocal1(_fuse);
-  _fuse=caml_alloc(1, Abstract_tag);
-  Store_field(_fuse, 0, (value) f);
+  _fuse = caml_alloc(1, Abstract_tag);
+  Store_field(_fuse, 0, (value)f);
 
-  CAMLreturnT(int, caml_callback2(*ocaml_fuse_loop_closure,_fuse,Val_bool(multithreaded)));
+  CAMLreturnT(int, caml_callback2(*ocaml_fuse_loop_closure, _fuse,
+                                  Val_bool(multithreaded)));
 }
 
-void ml_fuse_init()
-{
-  c2ml_unix_error_vect = invert_array(ml2c_unix_error_vect,&ml2c_unix_error_vect_dim,&c2ml_unix_error_vect_dim); /* TODO: this sucks together with the one at the beginning of file */
+void ml_fuse_init() {
+  c2ml_unix_error_vect = invert_array(
+      ml2c_unix_error_vect, &ml2c_unix_error_vect_dim,
+      &c2ml_unix_error_vect_dim); /* TODO: this sucks together with the one at
+                                     the beginning of file */
 }
 
-void ml_fuse_main(int argc,str * argv,struct fuse_operations const * op)
-{
+void ml_fuse_main(int argc, str *argv, struct fuse_operations const *op) {
   ocaml_fuse_loop_closure = caml_named_value("ocaml_fuse_loop");
   ocaml_list_length = caml_named_value("ocaml_list_length");
 
-  char * mountpoint;
+  char *mountpoint;
   int multithreaded;
   int fd;
 
-  struct fuse * fuse = fuse_setup(argc,argv,op,sizeof(struct fuse_operations),&mountpoint,&multithreaded,&fd);
+  struct fuse *fuse = fuse_setup(argc, argv, op, sizeof(struct fuse_operations),
+                                 &mountpoint, &multithreaded, &fd);
 
 #if OCAML_VERSION >= 50000
-  if (caml_atfork_hook != NULL) caml_atfork_hook();
+  if (caml_atfork_hook != NULL)
+    caml_atfork_hook();
 #endif
 
-  if (fuse!=NULL)
-    {
-      mainloop(fuse,multithreaded);
-      fuse_teardown(fuse,mountpoint);
-    }
+  if (fuse != NULL) {
+    mainloop(fuse, multithreaded);
+    fuse_teardown(fuse, mountpoint);
+  }
 }
 
 value ocaml_fuse_is_null(value v) /* For Com.opaque values */
 {
   CAMLparam1(v);
-  CAMLreturn(Val_bool(0==Field(v,0))); // Is this the right way to check for null?
+  CAMLreturn(
+      Val_bool(0 == Field(v, 0))); // Is this the right way to check for null?
 }

--- a/lib/Fuse_util.c
+++ b/lib/Fuse_util.c
@@ -623,9 +623,9 @@ FOR_ALL_OPS(DECLARE_OP_CLOSURE)
                                                                         \
   static OPNAME##_RTYPE ops_##OPNAME OPNAME##_ARGS                      \
   {                                                                     \
-    caml_leave_blocking_section();                                      \
+    caml_acquire_runtime_system();                                      \
     OPNAME##_RTYPE ret = gm281_ops_##OPNAME OPNAME##_CALL_ARGS;         \
-    caml_enter_blocking_section();                                      \
+    caml_release_runtime_system();                                      \
     return ret;                                                         \
   }
 

--- a/lib/Fuse_util.c
+++ b/lib/Fuse_util.c
@@ -61,12 +61,6 @@
 
 #define min(a, b) (a < b ? a : b)
 
-#if OCAML_VERSION >= 50000
-/* HACK: Internal hook to call after fork()
- * https://github.com/ocaml/ocaml/blob/5.1/runtime/caml/domain.h#L81 */
-CAMLextern void (*caml_atfork_hook)(void);
-#endif
-
 CAMLprim value callback4(value closure, value arg1, value arg2, value arg3,
                          value arg4) {
   CAMLparam5(closure, arg1, arg2, arg3, arg4);
@@ -729,11 +723,6 @@ void ml_fuse_main(int argc, str *argv, struct fuse_operations const *op) {
 
   struct fuse *fuse = fuse_setup(argc, argv, op, sizeof(struct fuse_operations),
                                  &mountpoint, &multithreaded, &fd);
-
-#if OCAML_VERSION >= 50000
-  if (caml_atfork_hook != NULL)
-    caml_atfork_hook();
-#endif
 
   if (fuse != NULL) {
     mainloop(fuse, multithreaded);

--- a/lib/Unix_util.ml
+++ b/lib/Unix_util.ml
@@ -72,7 +72,12 @@ let statvfs path =
   | Ok res -> res
   | Bad err -> raise (Unix.Unix_error (err, "statvfs", ""))
 
-external fchdir : Unix.file_descr -> unit = "unix_util_fchdir"
+external fchdir_noexn : Unix.file_descr -> unit result = "unix_util_fchdir"
+
+let fchdir path =
+  match fchdir_noexn path with
+  | Ok () -> ()
+  | Bad err -> raise (Unix.Unix_error (err, "fchdir", ""))
 
 let read fd buf =
   match read_noexn fd buf with
@@ -82,4 +87,4 @@ let read fd buf =
 let write fd buf =
   match write_noexn fd buf with
   | Ok res -> res
-  | Bad err -> raise (Unix.Unix_error (err, "read", ""))
+  | Bad err -> raise (Unix.Unix_error (err, "write", ""))

--- a/lib/Unix_util_stubs.c
+++ b/lib/Unix_util_stubs.c
@@ -120,8 +120,22 @@ CAMLprim value unix_util_file_descr_of_int(value fd)
 CAMLprim value unix_util_fchdir(value fd)
 {
   CAMLparam1(fd);
-  fchdir(Int_val(fd));
-  CAMLreturn (Val_unit);
+  CAMLlocal1(vres);
+  int res;
+  caml_release_runtime_system();
+  res = fchdir(Int_val(fd));
+  caml_acquire_runtime_system();
+  if (res >=0)
+    {
+      vres=caml_alloc(1,1); /* Ok result */
+      Store_field(vres,0,Val_unit);
+    }
+  else
+    {
+      vres=caml_alloc(1,0); /* Bad result */
+      Store_field(vres,0,Val_int(errno)); /* TODO: EUNKNOWN x is a block */
+    }
+  CAMLreturn (vres);
 }
 
 CAMLprim value copy_statvfs (struct statvfs *buf)

--- a/lib/Unix_util_stubs.c
+++ b/lib/Unix_util_stubs.c
@@ -30,10 +30,10 @@
 #define CAML_NAME_SPACE
 #endif
 
-#include <unistd.h>
+#include <errno.h>
 #include <stddef.h>
 #include <string.h>
-#include <errno.h>
+#include <unistd.h>
 #if defined(__APPLE__)
 #include <sys/mount.h>
 #else
@@ -41,143 +41,141 @@
 #endif
 #include <sys/statvfs.h>
 
-#include <caml/mlvalues.h>
-#include <caml/memory.h>
 #include <caml/alloc.h>
-#include <caml/fail.h>
 #include <caml/callback.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
 #include <caml/threads.h>
 #ifdef Custom_tag
-#include <caml/custom.h>
 #include <caml/bigarray.h>
+#include <caml/custom.h>
 #endif
 #include <caml/camlidlruntime.h>
 
 int c2ml_unix_error(int c_err);
 
-CAMLprim value unix_util_read(value fd,value buf)
-{
-  CAMLparam2(fd,buf);
+CAMLprim value unix_util_read(value fd, value buf) {
+  CAMLparam2(fd, buf);
   CAMLlocal1(vres);
   int res;
   int c_fd = Int_val(fd); /* TODO: unsafe coercion */
-  void * c_data = Caml_ba_data_val(buf);
+  void *c_data = Caml_ba_data_val(buf);
   int c_dim = Caml_ba_array_val(buf)->dim[0];
 
   caml_release_runtime_system();
   res = read(c_fd, c_data, c_dim);
   caml_acquire_runtime_system();
-  if (res >=0)
-    {
-      vres=caml_alloc(1,1); /* Ok result */
-      Store_field(vres,0,Val_int(res));
-    }
-  else
-    {
-      vres=caml_alloc(1,0); /* Bad result */
-      Store_field(vres,0,Val_int(c2ml_unix_error(res))); /* TODO: EUNKNOWN x is a block */
-    }
-  CAMLreturn (vres);
+  if (res >= 0) {
+    vres = caml_alloc(1, 1); /* Ok result */
+    Store_field(vres, 0, Val_int(res));
+  } else {
+    vres = caml_alloc(1, 0); /* Bad result */
+    Store_field(
+        vres, 0,
+        Val_int(c2ml_unix_error(res))); /* TODO: EUNKNOWN x is a block */
+  }
+  CAMLreturn(vres);
 }
 
-CAMLprim value unix_util_write(value fd,value buf)
-{
-  CAMLparam2(fd,buf);
+CAMLprim value unix_util_write(value fd, value buf) {
+  CAMLparam2(fd, buf);
   CAMLlocal1(vres);
   int res;
   int c_fd = Int_val(fd); /* TODO: unsafe coercion */
-  void * c_data = Caml_ba_data_val(buf);
+  void *c_data = Caml_ba_data_val(buf);
   int c_dim = Caml_ba_array_val(buf)->dim[0];
 
   caml_release_runtime_system();
   res = write(c_fd, c_data, c_dim);
   caml_acquire_runtime_system();
-  if (res >=0)
-    {
-      vres=caml_alloc(1,1); /* Ok result */
-      Store_field(vres,0,Val_int(res));
-    }
-  else
-    {
-      vres=caml_alloc(1,0); /* Bad result */
-      Store_field(vres,0,Val_int(c2ml_unix_error(res))); /* TODO: EUNKNOWN x is a block */
-    }
-  CAMLreturn (vres);
+  if (res >= 0) {
+    vres = caml_alloc(1, 1); /* Ok result */
+    Store_field(vres, 0, Val_int(res));
+  } else {
+    vres = caml_alloc(1, 0); /* Bad result */
+    Store_field(
+        vres, 0,
+        Val_int(c2ml_unix_error(res))); /* TODO: EUNKNOWN x is a block */
+  }
+  CAMLreturn(vres);
 }
 
-CAMLprim value unix_util_int_of_file_descr(value fd)
-{
+CAMLprim value unix_util_int_of_file_descr(value fd) {
   CAMLparam1(fd);
-  CAMLreturn (Val_int(Int_val(fd)) /* TODO: unsafe coercion */ );
+  CAMLreturn(Val_int(Int_val(fd)) /* TODO: unsafe coercion */);
 }
 
-CAMLprim value unix_util_file_descr_of_int(value fd)
-{
+CAMLprim value unix_util_file_descr_of_int(value fd) {
   CAMLparam1(fd);
-  CAMLreturn (Val_int(Int_val(fd) /* TODO: unsafe coercion */ ));
+  CAMLreturn(Val_int(Int_val(fd) /* TODO: unsafe coercion */));
 }
 
-CAMLprim value unix_util_fchdir(value fd)
-{
+CAMLprim value unix_util_fchdir(value fd) {
   CAMLparam1(fd);
   CAMLlocal1(vres);
   int res;
   caml_release_runtime_system();
   res = fchdir(Int_val(fd));
   caml_acquire_runtime_system();
-  if (res >=0)
-    {
-      vres=caml_alloc(1,1); /* Ok result */
-      Store_field(vres,0,Val_unit);
-    }
-  else
-    {
-      vres=caml_alloc(1,0); /* Bad result */
-      Store_field(vres,0,Val_int(errno)); /* TODO: EUNKNOWN x is a block */
-    }
-  CAMLreturn (vres);
+  if (res >= 0) {
+    vres = caml_alloc(1, 1); /* Ok result */
+    Store_field(vres, 0, Val_unit);
+  } else {
+    vres = caml_alloc(1, 0);              /* Bad result */
+    Store_field(vres, 0, Val_int(errno)); /* TODO: EUNKNOWN x is a block */
+  }
+  CAMLreturn(vres);
 }
 
-CAMLprim value copy_statvfs (struct statvfs *buf)
-{
-  CAMLparam0 ();
-  CAMLlocal2 (bufv,v);
-  bufv = caml_alloc (11, 0);
-  v=caml_copy_int64 (buf->f_bsize);caml_modify (&Field (bufv, 0),v);
-  v=caml_copy_int64 (buf->f_frsize);caml_modify (&Field (bufv, 1),v);
-  v=caml_copy_int64 (buf->f_blocks);caml_modify (&Field (bufv, 2),v);
-  v=caml_copy_int64 (buf->f_bfree);caml_modify (&Field (bufv, 3),v);
-  v=caml_copy_int64 (buf->f_bavail);caml_modify (&Field (bufv, 4),v);
-  v=caml_copy_int64 (buf->f_files);caml_modify (&Field (bufv, 5),v);
-  v=caml_copy_int64 (buf->f_ffree);caml_modify (&Field (bufv, 6),v);
-  v=caml_copy_int64 (buf->f_favail);caml_modify (&Field (bufv, 7),v);
-  v=caml_copy_int64 (buf->f_fsid);caml_modify (&Field (bufv, 8),v);
-  v=caml_copy_int64 (buf->f_flag);caml_modify (&Field (bufv, 9),v);
-  caml_copy_int64 (buf->f_namemax);caml_modify (&Field (bufv, 10),v);
-  CAMLreturn (bufv);
+CAMLprim value copy_statvfs(struct statvfs *buf) {
+  CAMLparam0();
+  CAMLlocal2(bufv, v);
+  bufv = caml_alloc(11, 0);
+  v = caml_copy_int64(buf->f_bsize);
+  caml_modify(&Field(bufv, 0), v);
+  v = caml_copy_int64(buf->f_frsize);
+  caml_modify(&Field(bufv, 1), v);
+  v = caml_copy_int64(buf->f_blocks);
+  caml_modify(&Field(bufv, 2), v);
+  v = caml_copy_int64(buf->f_bfree);
+  caml_modify(&Field(bufv, 3), v);
+  v = caml_copy_int64(buf->f_bavail);
+  caml_modify(&Field(bufv, 4), v);
+  v = caml_copy_int64(buf->f_files);
+  caml_modify(&Field(bufv, 5), v);
+  v = caml_copy_int64(buf->f_ffree);
+  caml_modify(&Field(bufv, 6), v);
+  v = caml_copy_int64(buf->f_favail);
+  caml_modify(&Field(bufv, 7), v);
+  v = caml_copy_int64(buf->f_fsid);
+  caml_modify(&Field(bufv, 8), v);
+  v = caml_copy_int64(buf->f_flag);
+  caml_modify(&Field(bufv, 9), v);
+  caml_copy_int64(buf->f_namemax);
+  caml_modify(&Field(bufv, 10), v);
+  CAMLreturn(bufv);
 }
 
-CAMLprim value unix_util_statvfs (value pathv)
-{
-  CAMLparam1 (pathv);
-  CAMLlocal2 (vres,bufv);
-  vres=caml_alloc(1,1); /* Ok result */
+CAMLprim value unix_util_statvfs(value pathv) {
+  CAMLparam1(pathv);
+  CAMLlocal2(vres, bufv);
+  vres = caml_alloc(1, 1); /* Ok result */
   bufv;
-  const char *path = String_val (pathv);
+  const char *path = String_val(pathv);
   struct statvfs buf;
   int res;
   caml_release_runtime_system();
-  res = statvfs(path,&buf);
+  res = statvfs(path, &buf);
   caml_acquire_runtime_system();
-  if (res >=0)
-    {
-      bufv = copy_statvfs (&buf);
-      Store_field(vres,0,bufv);
-    }
-  else
-    {
-      Tag_val(vres)=0; /* Bad result */
-      Store_field(vres,0,Val_int(c2ml_unix_error(res))); /* TODO: EUNKNOWN x is a block */
-    }
-  CAMLreturn (vres);
+  if (res >= 0) {
+    bufv = copy_statvfs(&buf);
+    Store_field(vres, 0, bufv);
+  } else {
+    Tag_val(vres) = 0; /* Bad result */
+    Store_field(
+        vres, 0,
+        Val_int(c2ml_unix_error(res))); /* TODO: EUNKNOWN x is a block */
+  }
+  CAMLreturn(vres);
 }

--- a/lib/Unix_util_stubs.c
+++ b/lib/Unix_util_stubs.c
@@ -64,9 +64,9 @@ CAMLprim value unix_util_read(value fd,value buf)
   void * c_data = Caml_ba_data_val(buf);
   int c_dim = Caml_ba_array_val(buf)->dim[0];
 
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
   res = read(c_fd, c_data, c_dim);
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
   if (res >=0)
     {
       vres=caml_alloc(1,1); /* Ok result */
@@ -89,9 +89,9 @@ CAMLprim value unix_util_write(value fd,value buf)
   void * c_data = Caml_ba_data_val(buf);
   int c_dim = Caml_ba_array_val(buf)->dim[0];
 
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
   res = write(c_fd, c_data, c_dim);
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
   if (res >=0)
     {
       vres=caml_alloc(1,1); /* Ok result */
@@ -152,9 +152,9 @@ CAMLprim value unix_util_statvfs (value pathv)
   const char *path = String_val (pathv);
   struct statvfs buf;
   int res;
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
   res = statvfs(path,&buf);
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
   if (res >=0)
     {
       bufv = copy_statvfs (&buf);

--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
  (flags -thread)
  (foreign_stubs
   (language c)
-  (names Fuse_bindings_stubs Fuse_util Unix_util_stubs)
+  (names Fuse_bindings_stubs Fuse_util Unix_util_stubs Fuse_main)
   (flags
    :standard
    (:include fuse.cflags.sexp)))


### PR DESCRIPTION
Fix #24

- Add `main` function in C
- Call `fuse_daemonize` before `caml_main`
- Add `-f` option to fuse args (to avoid a second call to `fuse_daemonize`)