### PR TITLE
Add `name` field to `dune-project`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,5 @@
 (lang dune 3.7)
+(name fuse3)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
This is required to be able to do a direct `opam pin` of the package source code.